### PR TITLE
ログインユーザーを取得できるエンドポイントの実装

### DIFF
--- a/app/accounts/views.py
+++ b/app/accounts/views.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from rest_framework import viewsets
 # from rest_framework.decorators import permission_classes
-from rest_framework.generics import ListCreateAPIView
+from rest_framework.generics import RetrieveAPIView
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenError, InvalidToken
@@ -17,10 +17,22 @@ class UserViewSet(viewsets.ModelViewSet):
     queryset = get_user_model().objects.filter(is_active=True)
     serializer_class = UserSerializer
 
-class UserProfileCreateView(ListCreateAPIView):
+class UserProfileCreateView(RetrieveAPIView):
     queryset = get_user_model().objects.all()
     serializer_class = UserSerializer
     permission_classes=[IsAuthenticated]
+
+    def get(self, request, format=None):
+        icon = request.user.icon.url if request.user.icon else 'No IMAGE'
+
+        return Response(data= {
+            'id': request.user.id,
+            'username': request.user.username,
+            'email': request.user.email,
+            'icon': icon,
+            'profile': request.user.profile
+        },
+        status=status.HTTP_200_OK)
 
 
 class LoginAPIView(TokenObtainPairView):

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -185,8 +185,8 @@ EMAIL_USE_TLS = True
 # Djoser
 DJOSER = {
     'LOGIN_FIELD': 'email', # メールアドレスでログイン
-    'SEND_ACTIVATION_EMAIL': True, # アカウント本登録メール
-    'SEND_CONFIRMATION_EMAIL': True, # アカウント本登録完了メール
+    # 'SEND_ACTIVATION_EMAIL': True, # アカウント本登録メール
+    # 'SEND_CONFIRMATION_EMAIL': True, # アカウント本登録完了メール
     'USERNAME_CHANGED_EMAIL_CONFIRMATION': True, # メールアドレス変更完了メール
     'PASSWORD_CHANGED_EMAIL_CONFIRMATION': True, # パスワード変更完了メール
     'USER_CREATE_PASSWORD_RETYPE': True, # 新規登録時に確認用パスワード必須


### PR DESCRIPTION
# 実装内容
- ログインユーザーを取得できるエンドポイントの実装
- 新規登録方法の変更

新規登録方法は、「仮登録→メールに記載されたurlに飛ぶとアカウントがactivateされて本登録完了」
という流れを想定していましたが、簡略化するため、フォームの入力に間違いが無ければ登録完了となるようにしました。

登録が弾かれるのは、以下の場合です。
- 既にメールアドレスが使用されている
- パスワードと確認パスワードが不一致 