### PR TITLE
room apiからplayer情報とユーザーの詳細を取得できるよう変更

### DIFF
--- a/app/drawing/serializers.py
+++ b/app/drawing/serializers.py
@@ -1,14 +1,25 @@
 from rest_framework import serializers
 from .models import Room, Member, ChatLog, Picture
 
+from accounts.serializers import UserSerializer
+
 
 class RoomSerializer(serializers.ModelSerializer):
+    members = serializers.SerializerMethodField()
     class Meta:
         model = Room
-        fields = ('id', 'name', 'password', 'entryNum', 'mode', 'level', 'round')
+        fields = ('id', 'name', 'password', 'entryNum', 'mode', 'level', 'round', 'members')
 
+    def get_members(self, obj):
+        try:
+            member_content = MemberSerializer(Member.objects.all().filter(room=Room.objects.get(id=obj.id)), many=True).data
+            return member_content
+        except:
+            member_content = None
+            return member_content
 
 class MemberSerializer(serializers.ModelSerializer):
+    user = UserSerializer(read_only=True)
     class Meta:
         model = Member
         fields = ('id', 'room', 'user', 'score')


### PR DESCRIPTION
# 実装内容
ルーム情報を取得した時に、ルームに参加しているメンバーの詳細情報まで取得できるように
変更しました。

# 出力
![image](https://user-images.githubusercontent.com/63044039/152502163-ebc2fc82-8d7d-467b-9fae-174cd57c94eb.png)
